### PR TITLE
compress ttl dumps

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ A config.json needs to be present under /config/config.json
     "targetGraph": "http://redpencil.data.gift/id/deltas/producer/loket-leidinggevenden-producer",
     "fileBaseName": "dump-leidinggevenden",
     "targetDcatGraph": "optional graph where the information of the data set should reside",
-    "targetFilesGraph": "optional graph where the meta data of the ttl should reside"
+    "targetFilesGraph": "optional graph where the meta data of the ttl should reside",
+    "compression": "optional, default false. If true, dumps are compressed as *.ttl.gz"
   }
 }
 ```

--- a/app.js
+++ b/app.js
@@ -51,7 +51,8 @@ async function produceDumpFile(config, task) {
                                        config.fileBaseName,
                                        config.publicationGraphEndpoint,
                                        config.targetDcatGraph,
-                                       config.targetFilesGraph);
+                                       config.targetFilesGraph,
+                                       config.compression);
     await updateStatus(task, STATUS_BUSY);
     await manager.createDumpFile();
     await updateStatus(task, STATUS_SUCCESS);

--- a/lib/dataset.js
+++ b/lib/dataset.js
@@ -78,6 +78,7 @@ export class DatasetManager {
     const fileName = path.basename(this.filePath);
     const extension = path.extname(this.filePath);
     const format = 'text/turtle';
+    const compressionFormat = 'http://www.iana.org/assignments/media-types/application/gzip';
     const fileStats = fs.statSync(this.filePath);
     const created = new Date(fileStats.birthtime);
     const size = fileStats.size;
@@ -102,6 +103,7 @@ export class DatasetManager {
             dct:format ${sparqlEscapeString(format)} ;
             nfo:fileSize ${sparqlEscapeInt(size)} ;
             dbpedia:fileExtension ${sparqlEscapeString(extension)} ;
+            dcat:compressFormat ${sparqlEscapeUri(compressionFormat)} ;
             dct:creator ${sparqlEscapeUri(SERVICE_NAME)} ;
             dct:created ${sparqlEscapeDateTime(created)} .
 
@@ -109,6 +111,7 @@ export class DatasetManager {
             mu:uuid ${sparqlEscapeString(physicalFileUuid)} ;
             nfo:fileName ${sparqlEscapeString(fileName)} ;
             dct:format ${sparqlEscapeString(format)} ;
+            dcat:compressFormat ${sparqlEscapeUri(compressionFormat)} ;
             nfo:fileSize ${sparqlEscapeInt(size)} ;
             dbpedia:fileExtension ${sparqlEscapeString(extension)} ;
             dct:created ${sparqlEscapeDateTime(created)} ;
@@ -123,6 +126,7 @@ export class DatasetManager {
             dct:issued ${sparqlEscapeDateTime(now)} ;
             dcat:byteSize ${sparqlEscapeInt(size)} ;
             dct:format ${sparqlEscapeString(format)} ;
+            dcat:compressFormat ${sparqlEscapeUri(compressionFormat)} ;
             dct:title ?title .
             ?dataset dcat:distribution ${sparqlEscapeUri(distributionUri)} .
         }

--- a/lib/dataset.js
+++ b/lib/dataset.js
@@ -12,19 +12,20 @@ import { PREFIXES, DCAT_DATASET_TYPE } from './constants';
  * Courtesy: https://github.com/Annelies-P, Erika
  */
 export class DatasetManager {
-  constructor(dcatDataSetSubject, graphToDump, fileBaseName, publicationGraphEndpoint, targetDcatGraph, targetFilesGraph){
+  constructor(dcatDataSetSubject, graphToDump, fileBaseName, publicationGraphEndpoint, targetDcatGraph, targetFilesGraph, compression){
     this.dcatDataSetSubject = dcatDataSetSubject;
     this.fileBaseName = fileBaseName;
     this.graphToDump = graphToDump;
     this.publicationGraphEndpoint = publicationGraphEndpoint || process.env.MU_SPARQL_ENDPOINT;
     this.dcatGraph = targetDcatGraph || DCAT_DATASET_GRAPH;
     this.filesGraph = targetFilesGraph || FILES_GRAPH;
+    this.compression = compression || false;
   }
   /**
    * @public
    */
   async createDumpFile() {
-    this.filePath = await generateDumpFile(this.fileBaseName, this.graphToDump, this.publicationGraphEndpoint);
+    this.filePath = await generateDumpFile(this.fileBaseName, this.compression, this.graphToDump, this.publicationGraphEndpoint);
     if(!this.filePath){
       return;
     }
@@ -103,9 +104,9 @@ export class DatasetManager {
             mu:uuid ${sparqlEscapeString(logicalFileUuid)} ;
             nfo:fileName ${sparqlEscapeString(fileName)} ;
             dct:format ${sparqlEscapeString(format)} ;
+            ${ this.compression ? (`dcat:compressFormat ${sparqlEscapeUri(compressionFormat)}`) : '' };
             nfo:fileSize ${sparqlEscapeInt(size)} ;
             dbpedia:fileExtension ${sparqlEscapeString(extension)} ;
-            dcat:compressFormat ${sparqlEscapeUri(compressionFormat)} ;
             dct:creator ${sparqlEscapeUri(SERVICE_NAME)} ;
             dct:created ${sparqlEscapeDateTime(created)} .
 
@@ -113,7 +114,7 @@ export class DatasetManager {
             mu:uuid ${sparqlEscapeString(physicalFileUuid)} ;
             nfo:fileName ${sparqlEscapeString(fileName)} ;
             dct:format ${sparqlEscapeString(format)} ;
-            dcat:compressFormat ${sparqlEscapeUri(compressionFormat)} ;
+            ${ this.compression ? (`dcat:compressFormat ${sparqlEscapeUri(compressionFormat)}`) : '' };
             nfo:fileSize ${sparqlEscapeInt(size)} ;
             dbpedia:fileExtension ${sparqlEscapeString(extension)} ;
             dct:created ${sparqlEscapeDateTime(created)} ;
@@ -128,7 +129,7 @@ export class DatasetManager {
             dct:issued ${sparqlEscapeDateTime(now)} ;
             dcat:byteSize ${sparqlEscapeInt(size)} ;
             dct:format ${sparqlEscapeString(format)} ;
-            dcat:compressFormat ${sparqlEscapeUri(compressionFormat)} ;
+            ${ this.compression ? (`dcat:compressFormat ${sparqlEscapeUri(compressionFormat)}`) : '' };
             dct:title ?title .
             ?dataset dcat:distribution ${sparqlEscapeUri(distributionUri)} .
         }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -1,13 +1,18 @@
 import fs from 'fs-extra';
+import { createGzip } from 'zlib';
+import { pipeline } from 'stream';
 import path from 'path';
-import {  sparqlEscapeString, uuid } from 'mu';
+import { sparqlEscapeString, uuid } from 'mu';
 import { sparqlEscapeUri } from './utils';
 import { countResourcesInGraph, getBatchedTriples, mayBeTaskOfInterest } from './queries';
 import { STATUS_SCHEDULED } from './constants';
+import { promisify } from 'util';
 import {
   EXPORT_TTL_BATCH_SIZE,
   RELATIVE_FILE_PATH
 } from './env';
+
+const pipe = promisify(pipeline);
 
 export async function getScheduledDumpTask(inserts) {
   const task = inserts.filter( triple => {
@@ -33,6 +38,7 @@ export async function generateDumpFile( fileBaseName, graphToDump, publicationGr
   fs.mkdirSync(outputDir, { recursive: true });
   const filename = `${fileBaseName}-${new Date().toISOString().replace(/-|T|Z|:|\./g, '')}-${uuid()}`;
   const ttlFile = path.join(outputDir, `${filename}.ttl`);
+  const gzFile = `${ttlFile}.gz`;
   const tmpFile = `${ttlFile}.tmp`;
   const count = await countResourcesInGraph(graphToDump, publicationGraphEndpoint);
 
@@ -44,9 +50,17 @@ export async function generateDumpFile( fileBaseName, graphToDump, publicationGr
   else {
     console.log(`Exporting 0/${count} resources`);
     await saveTriplesToFile(tmpFile, count, graphToDump, publicationGraphEndpoint);
-    await fs.rename(tmpFile, ttlFile);
-    return ttlFile;
+    await compressFile(tmpFile, gzFile);
+    fs.rm(tmpFile);
+    return gzFile;
   }
+}
+
+async function compressFile(input, output) {
+  const gzip = createGzip();
+  const source = fs.createReadStream(input);
+  const destination = fs.createWriteStream(output);
+  await pipe(source, gzip, destination);
 }
 
 async function saveTriplesToFile(file, count, graph, publicationGraphEndpoint) {

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -33,12 +33,11 @@ export async function getScheduledDumpTask(inserts) {
 /**
  * Export resources of a specific graph in Turtle format to a file.
 */
-export async function generateDumpFile( fileBaseName, graphToDump, publicationGraphEndpoint ) {
+export async function generateDumpFile( fileBaseName, compression, graphToDump, publicationGraphEndpoint ) {
   const outputDir = path.join('/share', RELATIVE_FILE_PATH, fileBaseName);
   fs.mkdirSync(outputDir, { recursive: true });
   const filename = `${fileBaseName}-${new Date().toISOString().replace(/-|T|Z|:|\./g, '')}-${uuid()}`;
   const ttlFile = path.join(outputDir, `${filename}.ttl`);
-  const gzFile = `${ttlFile}.gz`;
   const tmpFile = `${ttlFile}.tmp`;
   const count = await countResourcesInGraph(graphToDump, publicationGraphEndpoint);
 
@@ -50,9 +49,15 @@ export async function generateDumpFile( fileBaseName, graphToDump, publicationGr
   else {
     console.log(`Exporting 0/${count} resources`);
     await saveTriplesToFile(tmpFile, count, graphToDump, publicationGraphEndpoint);
-    await compressFile(tmpFile, gzFile);
-    fs.rm(tmpFile);
-    return gzFile;
+    if(compression) {
+      const gzFile = `${ttlFile}.gz`;
+      await compressFile(tmpFile, gzFile);
+      fs.rm(tmpFile);
+      return gzFile;
+    } else {
+      await fs.rename(tmpFile, ttlFile);
+      return ttlFile;
+    }
   }
 }
 

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   "author": "lblod",
   "license": "MIT",
   "dependencies": {
-    "@lblod/mu-auth-sudo": "git://github.com:lblod/mu-auth-sudo.git#bdbd063dc8e4d3a891c713a0077a54bc8a010ca1",
+    "@lblod/mu-auth-sudo": "^0.5.1",
     "fs-extra": "^10.0.0",
     "lodash.flatten": "^4.4.0",
     "path": "^0.12.7"


### PR DESCRIPTION
Compress ttl dumps at rest, resulting in about 90% reduction of the file size (~50mb -> 5mb).