### PR TITLE
Fix configurable batch size read as a string

### DIFF
--- a/lib/env.js
+++ b/lib/env.js
@@ -3,7 +3,7 @@
  */
 
 export const SERVICE_NAME = process.env.SERVICE_NAME || 'delta-producer-dump-file-publisher';
-export const EXPORT_TTL_BATCH_SIZE = process.env.EXPORT_TTL_BATCH_SIZE || 1000;
+export const EXPORT_TTL_BATCH_SIZE = parseInt(process.env.EXPORT_TTL_BATCH_SIZE || 1000);
 export const DUMP_FILE_CREATION_TASK_OPERATION = process.env.DUMP_FILE_CREATION_TASK_OPERATION || 'http://redpencil.data.gift/id/jobs/concept/TaskOperation/deltas/deltaDumpFileCreation';
 export const FILES_GRAPH = process.env.FILES_GRAPH || 'http://mu.semte.ch/graphs/public';
 export const DCAT_DATASET_GRAPH = process.env.DCAT_DATASET_GRAPH || 'http://mu.semte.ch/graphs/public';


### PR DESCRIPTION
As we were not forcing the environment input to be an int, we started to have strange offsets being the result of the addition of multiple strings. This PR forces the batch size to be an int, the offset can now be calculated normally.