### PR TITLE
feat: batch queries per subject

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,19 +68,20 @@ It should be configured as such :
 
 Provided [environment variables](https://docs.docker.com/compose/environment-variables/) by the service. These can be added in within the docker declaration.
 
-| Name                                | Description                                                           | Default                                                                                 |
-| ----------------------------------- | --------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
-| `SERVICE_NAME`                      | The name of the service                                               | `delta-producer-dump-file-publisher`                                                    |
-| `EXPORT_TTL_BATCH_SIZE`             | Size of the batched queries                                           | `1000`                                                                                  |
-| `DUMP_FILE_CREATION_TASK_OPERATION` | Uri of the dump task                                                  | `http://redpencil.data.gift/id/jobs/concept/TaskOperation/deltas/deltaDumpFileCreation` |
-| `FILES_GRAPH`                       | Graph to store the file (can be set per job too)                      | `http://mu.semte.ch/graphs/public`                                                      |
-| `DCAT_DATASET_GRAPH`                | Graph to store the dcat dataset (can be set per job too)              | `http://mu.semte.ch/graphs/public`                                                      |
-| `RELATIVE_FILE_PATH`                | relative path to store the files under                                | `delta-producer-dumps`                                                                  |
-| `JOBS_GRAPH`                        | graph where the jobs resides                                          | `http://mu.semte.ch/graphs/system/jobs`                                                 |
-| `GRAPH_TO_DUMP`                     | Graph to dump in file                                                 |                                                                                         |
-| `EXPORT_FILE_BASE_NAME`             | Base name of the dump file                                            |                                                                                         |
-| `DUMP_FILE_CREATION_JOB_OPERATION`  | Uri of the dump task's job                                            |                                                                                         |
-| `DCAT_DATASET_SUBJECT`              | The dct:subject URI of the dataset                                    |                                                                                         |
+| Name                                | Description                                                                                                                           | Default                                                                                 |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------------------------------------- |
+| `SERVICE_NAME`                      | The name of the service                                                                                                               | `delta-producer-dump-file-publisher`                                                    |
+| `EXPORT_TTL_BATCH_SIZE`             | Size of the batched queries                                                                                                           | `1000`                                                                                  |
+| `DUMP_FILE_CREATION_TASK_OPERATION` | Uri of the dump task                                                                                                                  | `http://redpencil.data.gift/id/jobs/concept/TaskOperation/deltas/deltaDumpFileCreation` |
+| `FILES_GRAPH`                       | Graph to store the file (can be set per job too)                                                                                      | `http://mu.semte.ch/graphs/public`                                                      |
+| `DCAT_DATASET_GRAPH`                | Graph to store the dcat dataset (can be set per job too)                                                                              | `http://mu.semte.ch/graphs/public`                                                      |
+| `RELATIVE_FILE_PATH`                | relative path to store the files under                                                                                                | `delta-producer-dumps`                                                                  |
+| `JOBS_GRAPH`                        | graph where the jobs resides                                                                                                          | `http://mu.semte.ch/graphs/system/jobs`                                                 |
+| `GRAPH_TO_DUMP`                     | Graph to dump in file                                                                                                                 |                                                                                         |
+| `EXPORT_FILE_BASE_NAME`             | Base name of the dump file                                                                                                            |                                                                                         |
+| `DUMP_FILE_CREATION_JOB_OPERATION`  | Uri of the dump task's job                                                                                                            |                                                                                         |
+| `DCAT_DATASET_SUBJECT`              | The dct:subject URI of the dataset                                                                                                    |                                                                                         |
+| `MAX_SUBJECT_COUNT`                 | Batch size for the distinct subject query, should be at most the `ResultSetMaxRows` value as configured in the virtuoso configuration | 1000000                                                                                 |
 
 
 ## API

--- a/lib/env.js
+++ b/lib/env.js
@@ -9,3 +9,4 @@ export const FILES_GRAPH = process.env.FILES_GRAPH || 'http://mu.semte.ch/graphs
 export const DCAT_DATASET_GRAPH = process.env.DCAT_DATASET_GRAPH || 'http://mu.semte.ch/graphs/public';
 export const RELATIVE_FILE_PATH = process.env.RELATIVE_FILE_PATH || 'delta-producer-dumps';
 export const JOBS_GRAPH =  process.env.JOBS_GRAPH || 'http://mu.semte.ch/graphs/system/jobs';
+export const MAX_SUBJECT_COUNT = parseInt(process.env.MAX_SUBJECT_COUNT || 1000000)

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -2,7 +2,7 @@ import fs from 'fs-extra';
 import path from 'path';
 import {  sparqlEscapeString, uuid } from 'mu';
 import { sparqlEscapeUri } from './utils';
-import { countResourcesInGraph, getBatchedTriples, mayBeTaskOfInterest } from './queries';
+import {getResourcesInGraph, getBatchedTriples, mayBeTaskOfInterest, countResourcesInGraph} from './queries';
 import { STATUS_SCHEDULED } from './constants';
 import {
   EXPORT_TTL_BATCH_SIZE,
@@ -34,16 +34,16 @@ export async function generateDumpFile( fileBaseName, graphToDump, publicationGr
   const filename = `${fileBaseName}-${new Date().toISOString().replace(/-|T|Z|:|\./g, '')}-${uuid()}`;
   const ttlFile = path.join(outputDir, `${filename}.ttl`);
   const tmpFile = `${ttlFile}.tmp`;
-  const count = await countResourcesInGraph(graphToDump, publicationGraphEndpoint);
+  const resources = await getResourcesInGraph(graphToDump, publicationGraphEndpoint);
 
   //TODO: this flow should be somewhere else
-  if(count == 0){
+  if(resources.length === 0){
     console.log('No triples found, nothing to do');
     return null;
   }
   else {
-    console.log(`Exporting 0/${count} resources`);
-    await saveTriplesToFile(tmpFile, count, graphToDump, publicationGraphEndpoint);
+    console.log(`Exporting 0/${resources.length} resources`);
+    await saveTriplesToFile(tmpFile, resources, graphToDump, publicationGraphEndpoint);
     await fs.rename(tmpFile, ttlFile);
     return ttlFile;
   }
@@ -54,10 +54,12 @@ export async function deleteDumpFile(pFile) {
   await fs.unlink(filePath);
 }
 
-async function saveTriplesToFile(file, count, graph, publicationGraphEndpoint) {
+async function saveTriplesToFile(file, resources, graph, publicationGraphEndpoint) {
   let offset = 0;
+  let count = resources.length;
   while (offset < count) {
-    const triples = await getBatchedTriples(offset, graph, publicationGraphEndpoint);
+    const subjects = resources.slice(offset, offset+EXPORT_TTL_BATCH_SIZE);
+    const triples = await getBatchedTriples(subjects, graph, publicationGraphEndpoint);
     let serializedTriples = triples.map(t => serializeTriple(t)).join('\n');
     serializedTriples = serializedTriples + '\n'; //Make sure to end on new line, else virtuoso does not like it`
     fs.appendFileSync(file, serializedTriples);

--- a/lib/queries.js
+++ b/lib/queries.js
@@ -1,6 +1,7 @@
 import { querySudo as query, updateSudo as update } from '@lblod/mu-auth-sudo';
 import { uuid, sparqlEscapeString, sparqlEscapeDateTime } from 'mu';
 import { parseResult, sparqlEscapeUri } from './utils';
+import { isUri } from 'valid-url';
 
 import {
   ERROR_URI_PREFIX,
@@ -13,9 +14,9 @@ import {
   ERROR_CREATOR_URI
 } from './constants';
 import {
-  EXPORT_TTL_BATCH_SIZE,
   DUMP_FILE_CREATION_TASK_OPERATION,
-  JOBS_GRAPH
+  JOBS_GRAPH,
+  MAX_SUBJECT_COUNT
 } from './env';
 
 /**
@@ -44,8 +45,30 @@ export async function updateStatus(uri, status) {
   await update(q);
 }
 
-export async function countResourcesInGraph(graph, publicationGraphEndpoint) {
+export async function getResourcesInGraph(graph, publicationGraphEndpoint) {
   console.log(`Hitting publicationGraphEndpoint ${publicationGraphEndpoint}`);
+  const count = await countResourcesInGraph(graph, publicationGraphEndpoint);
+  let subjects = [];
+  while (subjects.length < count) {
+    const queryResult = await query(`
+      SELECT DISTINCT(?s)
+      WHERE {
+        GRAPH ${sparqlEscapeUri(graph)} {
+          ?s ?p ?o .
+        }
+      }
+      ORDER BY ?s
+      LIMIT ${MAX_SUBJECT_COUNT}
+      OFFSET ${subjects.length}
+    `, {}, {sparqlEndpoint: publicationGraphEndpoint});
+    queryResult.results.bindings.map(e=>e['s'].value).forEach(e=>subjects.push(e))
+  }
+
+  // filter out subjects that are not a uri, since this may cause errors
+  return subjects.filter(isUri)
+}
+
+export async function countResourcesInGraph(graph, publicationGraphEndpoint) {
   const queryResult = await query(`
       SELECT (COUNT( DISTINCT(?s)) as ?count)
       WHERE {
@@ -58,22 +81,14 @@ export async function countResourcesInGraph(graph, publicationGraphEndpoint) {
   return parseInt(queryResult.results.bindings[0].count.value);
 }
 
-export async function getBatchedTriples(offset, graph, publicationGraphEndpoint) {
+
+export async function getBatchedTriples(subjects, graph, publicationGraphEndpoint) {
   console.log(`Hitting publicationGraphEndpoint ${publicationGraphEndpoint}`);
   const q = `
     SELECT DISTINCT ?s ?p ?o
     WHERE {
       GRAPH ${sparqlEscapeUri(graph)} {
-        {
-          SELECT DISTINCT ?s WHERE {
-            GRAPH ${sparqlEscapeUri(graph)} {
-              ?s ?p ?o .
-            }
-          }
-          ORDER BY ?s
-          LIMIT ${EXPORT_TTL_BATCH_SIZE}
-          OFFSET ${offset}
-        }
+        VALUES ?s {${subjects.map(subject => sparqlEscapeUri(subject)).join(" ")}}
         ?s ?p ?o .
       }
     }

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "@lblod/mu-auth-sudo": "^0.6.0",
     "fs-extra": "^10.0.0",
     "lodash.flatten": "^4.4.0",
-    "path": "^0.12.7"
+    "path": "^0.12.7",
+    "valid-url": "^1.0.9"
   }
 }


### PR DESCRIPTION
Update dump generation to cache the list of subjects and then query them in batches.
This update improves the generation time for a dump file from more than 5 hours to under 10 minutes.